### PR TITLE
Preserve each node in browser history. Reload previous node when back…

### DIFF
--- a/resources/js/code.js
+++ b/resources/js/code.js
@@ -3,6 +3,9 @@ $('#nav-icon').click(function(){
 $(this).toggleClass('open');
 $(nav).toggleClass('open');
 });
+window.addEventListener('popstate', function() {
+location.reload();
+}, false);
 });
 function getParameterByName(name) {
 var url = window.location.href;
@@ -530,6 +533,8 @@ SetDefaultStyle(allElements[i]);
 }
 cy.elements().removeClass('mainNode');
 var newnode = e.cyTarget;
+window.history.pushState(null, 'The Kanji Map - '+e.cyTarget.data('id'), '/index.html?k='+e.cyTarget.data('id'));
+// alert(e.cyTarget.data('id'));
 newnode.addClass('mainNode');
 var activenodes = newnode.predecessors().add(newnode).add(newnode.outgoers());
 allElements.hide();


### PR DESCRIPTION
This approach is a good start - each node is saved in browser history (so the user can copy the URL and get a direct link to a node), and when the back button is pressed, the whole page reloads so the correct node is displayed. 

However, it would be better to refactor the code to select a node into a new method, and then call that instead of location.reload. Then it would be as if the user had literally just stepped back to the prior node within the app.